### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
   def item_params
     params.require(:item).permit(:image, :name, :info, :category_id, :sales_status_id, :shipping_fee_status_id, :prefecture_id, :scheduled_delivery_id, :price).merge(user_id:current_user.id)

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
       <% if @items[0] != nil %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id), method: :get do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
 
@@ -153,8 +153,10 @@
                 </div>
               </div>
             </div>
+              <% end %>
             <% end %>
-        <% end %>
+
+        
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,112 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class='item-img-content'>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <div class='sold-out'>
+        <span>Sold Out!!</span>
+      </div>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        <%= @item.price %>
+      </span>
+      <span class="item-postage">
+        <%= @item.shipping_fee_status.name %>
+      </span>
+    </div>
+
+    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
+      <% if current_user.id==@item.user.id %>
+        <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+      <% elsif '商品が出品中かどうか' %>
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+        <%# //商品が売れていない場合はこちらを表示しましょう %>
+      <% end %>
+    <% end %>
+
+    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+    <div class="item-explain-box">
+      <span><%= @item.info %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.sales_status.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.shipping_fee_status.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
+  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+</div>
+
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index ,:new ,:create]
+  resources :items, only: [:index ,:new ,:create, :show]
 end


### PR DESCRIPTION
# WHY
商品詳細表示機能実装

# WHY
トップページの商品一覧から出品者は編集削除ができるようにするため。
出品者以外の人は購入画面に進めるようにするため。

# 実装内容
1.ログアウト状態でも商品詳細ページを閲覧できること
https://gyazo.com/6d2a7de7744c97143c7e1862a5502187

2.出品者にしか商品の編集・削除のリンクが踏めないようになっていること
https://gyazo.com/9fc37f5501cd94fc519b565b21974e22

3.出品者以外（且つログインしたユーザー）のみ商品購入のリンクが踏めること
https://gyazo.com/2f9a6578f1371d529dd7aff03eb02b89

4.商品出品時に登録した情報が見られるようになっていること
5.画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
アプリの画面
https://gyazo.com/ad5a15274628f7cf6e23f5b52b0dcc45

データベース登録内容
https://gyazo.com/fbf54f86643ae7449ab0d5c4d0cc8caf

２と３は商品編集・削除・購入機能が未実装のため、現状はボタンが表示できるのみです。各機能実装後にボタンクリック時にリンクに飛ぶように編集いたします。
実装内容の確認お願いいたします。